### PR TITLE
Add a `itp` snippet to use `jsc.assertForall`

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -129,6 +129,21 @@
     "prefix": "ita",
     "scope": "source.js"
   },
+  "it.jsc.assertForall": {
+    "prefix": "itp",
+    "description": "Creates an `it` block with `jsc.assertForall` for property based testing",
+    "body": [
+      "it('${1:should }', () => {",
+      "\tjsc.assertForall(",
+      "\t\t$2,",
+      "\t\t($3) => {",
+      "\t\t\t$0",
+      "\t\t}",
+      "\t)",
+      "});"
+    ],
+    "scope": "source.js"
+  },
   "jest.fn": {
     "body": "jest.fn($0)",
     "description": "creates jest.fn()",
@@ -190,6 +205,21 @@
     "body": "test('${1:should }', async () => {\n\t$0\n});",
     "description": "creates an test block with async callback function",
     "prefix": "testa",
+    "scope": "source.js"
+  },
+  "test.jsc.assertForall": {
+    "prefix": "testp",
+    "description": "Creates a `test` block with `jsc.assertForall` for property based testing",
+    "body": [
+      "test('${1:should }', () => {",
+      "\tjsc.assertForall(",
+      "\t\t$2,",
+      "\t\t($3) => {",
+      "\t\t\t$0",
+      "\t\t}",
+      "\t)",
+      "});"
+    ],
     "scope": "source.js"
   },
   "toBe": {


### PR DESCRIPTION
It allows to create a new test to test a property using [jsverify](https://github.com/jsverify/jsverify). `itp` stands for _« it (has the) property »_.

Here is an example of generated `it` call:

```js
  describe("Addition", () => {
    it("should be commutative", () => {
      jsc.assertForall(jsc.integer, jsc.integer, (a, b) => {
        return a + b === b + a;
      });
    });
  });
```

I found using `jsc.assertForall` to be better supported by all the Jest ecosystem (tooling) than the `jsc.property` « magic » method, in terms of error messages and integrated tools (such as https://github.com/jest-community/vscode-jest/).

This snippet aims at making it easy to start with <abbr title="Property Based Testing">PBT</abbr>!

Feel free to discard this PR if you think that jest-jsverify snippets are out of your project’s scope.