### PR TITLE
feat: update snippets for Jest 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `descs→` | describe.skip         |
 | `desce→` | describe.each         |
 |    `ae→` | afterEach             |
+|   `aea→` | afterEach(async ...)  |
 |    `aa→` | afterAll              |
+|   `aaa→` | afterAll(async ...)   |
 |    `be→` | beforeEach            |
 |   `bea→` | beforeEach(async ...) |
 |    `ba→` | beforeAll             |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 |  `thbct→` | toHaveBeenCalledTimes              |
 |  `thbcw→` | toHaveBeenCalledWith               |
 | `thblcw→` | toHaveBeenLastCalledWith           |
+| `thbncw→` | toHaveBeenNthCalledWith            |
 |    `thl→` | toHaveLength                       |
 |  `thlrw→` | toHaveLastReturnedWith             |
 |  `thnrw→` | toHaveNthReturnedWith              |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Below is a list of all available snippets and the triggers of each one. The **�
 |    `tms→` | toMatchSnapshot                    |
 |   `tmis→` | toMatchInlineSnapshot              |
 |     `tt→` | toThrow                            |
-|    `tte→` | toThrowError                       |
 |  `ttems→` | toThrowErrorMatchingSnapshot       |
 | `ttemis→` | toThrowErrorMatchingInlineSnapshot |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ Below is a list of all available snippets and the triggers of each one. The **�
 |  `thbcw→` | toHaveBeenCalledWith               |
 | `thblcw→` | toHaveBeenLastCalledWith           |
 |    `thl→` | toHaveLength                       |
+|  `thlrw→` | toHaveLastReturnedWith             |
+|  `thnrw→` | toHaveNthReturnedWith              |
 |    `thp→` | toHaveProperty                     |
+|    `thr→` | toHaveReturned                     |
+|   `thrt→` | toHaveReturnedTimes                |
+|   `thrw→` | toHaveReturnedWith                 |
 |     `tm→` | toMatch                            |
 |    `tmo→` | toMatchObject                      |
 |    `tms→` | toMatchSnapshot                    |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | ------: | ----------------------- |
 |  `cut→` | test a class under test |
 |  `jfn→` | jest.fn                 |
+|  `jso→` | jest.spyOn              |
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jest-snippets",
   "displayName": "Jest Snippets",
   "description": "Code snippets for testing framework Jest",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "publisher": "andys8",
   "icon": "images/jest_snippets_icon.png",
   "license": "MIT",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -332,6 +332,12 @@
     "prefix": "thblcw",
     "scope": "source.js"
   },
+  "toHaveBeenNthCalledWith": {
+    "body": "expect($1).toHaveBeenNthCalledWith(${2:n}, $3);$0",
+    "description": "returns true if the spy has been called with on the nth call",
+    "prefix": "thbncw",
+    "scope": "source.js"
+  },
   "toHaveLastReturnedWith": {
     "body": "expect($1).toHaveLastReturnedWith($2);$0",
     "description": "returns true if the mock function last returned the specified value",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -380,12 +380,6 @@
     "prefix": "tt",
     "scope": "source.js"
   },
-  "toThrowError": {
-    "body": "expect(() => {\n\t$0\n}).toThrowError($1);",
-    "description": "expects that the method will throw an error",
-    "prefix": "tte",
-    "scope": "source.js"
-  },
   "toThrowErrorMatchingInlineSnapshot": {
     "body": "expect(() => {\n\t$0\n}).toThrowErrorMatchingInlineSnapshot();",
     "description": "expects that the method will throw an error matching the inline snapshot",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -159,6 +159,12 @@
     "prefix": "jfn",
     "scope": "source.js"
   },
+  "jest.spyOn": {
+    "body": "jest.spyOn(${1:object}, '${2:methodName}')$0",
+    "description": "creates jest.spyOn()",
+    "prefix": "jso",
+    "scope": "source.js"
+  },
   "template:cut": {
     "body": [
       "describe('${1:Name of the group}', () => {\n",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,10 +5,22 @@
     "prefix": "aa",
     "scope": "source.js"
   },
+  "afterAll:async": {
+    "body": "afterAll(async () => {\n\t$0\n});",
+    "description": "afterAll with async function is called once after all specs",
+    "prefix": "aaa",
+    "scope": "source.js"
+  },
   "afterEach": {
     "body": "afterEach(() => {\n\t$0\n});",
     "description": "afterEach function is called once after each spec",
     "prefix": "ae",
+    "scope": "source.js"
+  },
+  "afterEach:async": {
+    "body": "afterEach(async () => {\n\t$0\n});",
+    "description": "afterEach with async function is called once after each spec",
+    "prefix": "aea",
     "scope": "source.js"
   },
   "beforeAll": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -332,16 +332,46 @@
     "prefix": "thblcw",
     "scope": "source.js"
   },
+  "toHaveLastReturnedWith": {
+    "body": "expect($1).toHaveLastReturnedWith($2);$0",
+    "description": "returns true if the mock function last returned the specified value",
+    "prefix": "thlrw",
+    "scope": "source.js"
+  },
   "toHaveLength": {
     "body": "expect($1).toHaveLength($2);$0",
     "description": "expects the object to have length",
     "prefix": "thl",
     "scope": "source.js"
   },
+  "toHaveNthReturnedWith": {
+    "body": "expect($1).toHaveNthReturnedWith(${2:n}, $3);$0",
+    "description": "returns true if the mock function returned the specified value on the nth call",
+    "prefix": "thnrw",
+    "scope": "source.js"
+  },
   "toHaveProperty": {
     "body": "expect($1).toHaveProperty(${2:keyPath}, ${3:value});$0",
     "description": "returns true if the argument matches the second object",
     "prefix": "thp",
+    "scope": "source.js"
+  },
+  "toHaveReturned": {
+    "body": "expect($1).toHaveReturned();$0",
+    "description": "returns true if the mock function returned successfully",
+    "prefix": "thr",
+    "scope": "source.js"
+  },
+  "toHaveReturnedTimes": {
+    "body": "expect($1).toHaveReturnedTimes($2);$0",
+    "description": "returns true if the mock function returned the specified number of times",
+    "prefix": "thrt",
+    "scope": "source.js"
+  },
+  "toHaveReturnedWith": {
+    "body": "expect($1).toHaveReturnedWith($2);$0",
+    "description": "returns true if the mock function returned the specified value",
+    "prefix": "thrw",
     "scope": "source.js"
   },
   "toMatch": {


### PR DESCRIPTION
Removes the deprecated `toThrowError` snippet (`tte`) which was removed in Jest 30, and adds 9 new snippets for long-standing matchers that were missing.

**Removed (1):**
- `tte` - `toThrowError` (alias for `toThrow`, removed in Jest 30)

**Added (9):**
- `thr`, `thrt`, `thrw`, `thlrw`, `thnrw` - mock return value matchers
- `thbncw` - `toHaveBeenNthCalledWith`
- `aaa`, `aea` - async `afterAll`/`afterEach` (matching existing `baa`/`bea`)
- `jso` - `jest.spyOn`

Total snippets: 51 (was 43). Version bumped to 2.0.0 since removing `tte` is a breaking change.